### PR TITLE
Build project

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <algorithm>
+#include <stdexcept>
 #ifdef ARENA_DEBUG
 #include <iomanip>
 #include <iostream>

--- a/src/util/bip32.h
+++ b/src/util/bip32.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_BIP32_H
 
 #include <attributes.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <locale>
 #include <sstream>


### PR DESCRIPTION
```
Fixes compilation errors by adding missing C++ standard library includes.

**Motivation:**
During a standard build process of Bitcoin Core, compilation errors were encountered due to missing C++ standard library includes for types and exceptions (`std::runtime_error`, `uint32_t`, `uint8_t`).

**Improvement:**
This patch adds the necessary includes (`<stdexcept>`, `<cstdint>`) to the affected files, allowing Bitcoin Core to compile successfully on modern systems. This improves the developer experience by ensuring a smooth build process.

**Changes:**
*   `src/support/lockedpool.cpp`: Added `#include <stdexcept>`
*   `src/util/bip32.h`: Added `#include <cstdint>`
*   `src/util/string.h`: Added `#include <cstdint>`

**Tests:**
This is a build fix. The changes enable successful compilation.
```

---

[Open in Web](https://www.cursor.com/agents?id=bc-30c0e0df-9ab4-4f4e-8070-0099ec70b190) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-30c0e0df-9ab4-4f4e-8070-0099ec70b190)